### PR TITLE
Changed separator to `,`

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -63,7 +63,7 @@ client.indices.exists({	index: 'participants' }).then(function(data) {
 function injectCSV() {
 	var curId = 0;
 
-	csv.fromPath("inscrits.csv", { headers: true, delimiter: ';', trim: true })
+	csv.fromPath("inscrits.csv", { headers: true, delimiter: ',', trim: true })
 		.transform(function(data) {
 
 			curId++;


### PR DESCRIPTION
The file `inscrits.csv` now uses the standard `,` separator (to make it readable on GitHub).